### PR TITLE
add logic to solve for window not defined error; fix line indents

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,30 +8,34 @@ import ControlInput from '../src/js/controls.js';
 // import 'bootstrap/dist/css/bootstrap.min.css';
 // import './css/styles.css';
 
-window.addEventListener("load", function(){
-  const canvas = document.getElementById("canvas-1");
-  const ctx = canvas.getContext("2d");
-  canvas.width = 800;
-  canvas.height = 720;
+if (typeof window !== 'undefined') { //You are on the browser; can use window here
+  window.addEventListener("load", function(){
+    const canvas = document.getElementById("canvas-1");
+    const ctx = canvas.getContext("2d");
+    canvas.width = 800;
+    canvas.height = 720;
 
-  const input = new ControlInput();
-  const player = new Player(canvas.width, canvas.height);
-  const background = new Background(canvas.width, canvas.height);
-  
+    const input = new ControlInput();
+    const player = new Player(canvas.width, canvas.height);
+    const background = new Background(canvas.width, canvas.height);
     
-  // Display score || Game Over text
+      
+    // Display score || Game Over text
 
-  // function displayStatus(){
+    // function displayStatus(){
 
-  // }
-  function animationLoop(){
-    ctx.clearRect(0,0,canvas.width, canvas.height);
-    background.draw(ctx);
-    //background.update();
-    player.draw(ctx);
-    player.update(input);
-    requestAnimationFrame(animationLoop);
+    // }
+    function animationLoop(){
+      ctx.clearRect(0,0,canvas.width, canvas.height);
+      background.draw(ctx);
+      //background.update();
+      player.draw(ctx);
+      player.update(input);
+      requestAnimationFrame(animationLoop);
 
-  }
-  animationLoop();
-});
+    }
+    animationLoop();
+  });
+
+} else { //You are on the server; don't use window here
+}


### PR DESCRIPTION
Some clues and explanations of the error:
Just one of the gotchas of server-side rendering with React.
When Node tries to build, it instantiates the class, and in the constructor finds window, which is a browser global (Node doesn’t have window). https://github.com/gatsbyjs/gatsby/issues/5835

Some of your code references “browser globals” like window or document that aren’t available in Node.js. If this is your problem you should see an error above like “window is not defined”. To fix this, find the offending code and either a) check before calling the code if window is defined so the code doesn’t run while Gatsby is building (see code sample below) or b) if the code is in the render function of a React.js component, move that code into...
https://www.gatsbyjs.com/docs/debugging-html-builds/#how-to-check-if-code-classlanguage-textwindowcode-is-defined

Solution was to wrap our code in an if/else block that checks is window is defined, (which it should be when the code is interpreted in the browser.)
https://bobbyhadz.com/blog/javascript-referenceerror-window-is-not-defined#:~:text=the%20following%20way%3A-,index.js,are%20on%20the%20server%27)%0A%20%20//%20%E2%9B%94%EF%B8%8F%20Don%27t%20use%20window%20here%0A%7D,-We%20check%20if